### PR TITLE
Fixes for the C implementation

### DIFF
--- a/cache_size.c
+++ b/cache_size.c
@@ -15,7 +15,7 @@
 #define MIN_STRIDE 16
 #define STRIDES_MAGNITUDE 8
 
-static char measurement_array[MAX_ARRAY_SIZE];
+static volatile char measurement_array[MAX_ARRAY_SIZE];
 
 // https://stackoverflow.com/questions/3898840/converting-a-number-of-bytes-into-a-file-size-in-c
 void printsize(int size) {

--- a/cache_size.c
+++ b/cache_size.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <math.h>
+#include <string.h>
 
 #define NUM_ACCESSES (1 << 24)
 
@@ -55,6 +56,8 @@ double measure(int array_size, int stride) {
 
 int main() {
   double * results = malloc(sizeof(double) * SIZE_MAGNITUDE * STRIDES_MAGNITUDE);
+
+  memset((char *)measurement_array, 0, sizeof(measurement_array));
 
   printf("Showing avg time to access memory in nanoseconds. Rows are array size, columns are stride\n");
   printf("-------");


### PR DESCRIPTION
* Ensure measurement_array is not mapped on the CoW zero page
Otherwise, page faults are generated when measure() is executing, affecting the execution time.

* Mark the measurement_array as volatile to force the compiler to generate accesses
Otherwise, GCC 6.2.1 and presumably other compilers as well don't generate writes to the array in measure().
